### PR TITLE
Drop incomplete weeks

### DIFF
--- a/inst/app/server.r
+++ b/inst/app/server.r
@@ -3,7 +3,7 @@ library(plotly)
 function(input, output){
   tidyData <- notificationGraphs::tidy_results   
   mindate <- min(tidyData$sent_week_start_date)
-  maxdate <- max(tidyData$sent_week_start_date)
+  maxdate <- max(tidyData$sent_week_start_date) - 7
 
   output$plot <- renderPlotly({
     notificationGraphs::convert_tidy_to_plot(tidyData

--- a/inst/app/ui.r
+++ b/inst/app/ui.r
@@ -2,7 +2,7 @@ library(plotly)
 
 tidyData <- notificationGraphs::tidy_results   
 mindate <- min(tidyData$sent_week_start_date)
-maxdate <- max(tidyData$sent_week_start_date)
+maxdate <- max(tidyData$sent_week_start_date) - 7
 event_type_choices <- as.list(unique(tidyData$event_type))
 
 fluidPage(


### PR DESCRIPTION
Results for the most recent week are unreliable, because they only represent the day that the data was updated, rather than a whole week. The app's server and ui scripts need to drop this data point from the results.